### PR TITLE
Não usa seeds no teste de utils

### DIFF
--- a/test/server/utils.spec.js
+++ b/test/server/utils.spec.js
@@ -26,7 +26,6 @@ describe('utils', () => {
   beforeEach(async done => {
     await db.knex.migrate.rollback()
     await db.knex.migrate.latest()
-    await db.knex.seed.run()
     done()
   }, 100000)
 


### PR DESCRIPTION
Já que o teste trabalha em importar usuários,
as seeds ficam redundantes.