### PR TITLE
Formata hora de acordo com modelo de divulgação

### DIFF
--- a/components/TccDefenseSearch.vue
+++ b/components/TccDefenseSearch.vue
@@ -685,6 +685,8 @@ function hourFormatted(defenseHour) {
     .join('h')
     // '00h00'
     .slice(0, 5)
+    // '00h00min'
+    .concat('min')
 
   return hour
 }


### PR DESCRIPTION
Observei que no modelo de divulgação, a hora apresenta apresenta o formato com na image:
![image](https://user-images.githubusercontent.com/26655732/60988835-e51ef800-a31a-11e9-8ebb-ade69f758646.png)
Então fiz essa alteração no modelo de divulgação.