### PR TITLE
Adiciona course tag para autocomplete no DefenseForm

### DIFF
--- a/components/DefenseForm.vue
+++ b/components/DefenseForm.vue
@@ -577,6 +577,7 @@ export default {
       return this.$services.students
         .fetchPage({
           name: `%${name}%`,
+          course: this.courseTag,
           noDefense: true
         })
         .then(res => {


### PR DESCRIPTION
Evitar que alunos de um curso possam realizar defesa em nome de outro curso